### PR TITLE
fix: update Go bindings to match Rust implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,3 +146,13 @@ pub unsafe extern "C" fn free_string(s: *mut c_char) {
         drop(CString::from_raw(s));
     }
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn free_compile_result(result: CompileResult) {
+    if !result.result.is_null() {
+        drop(CString::from_raw(result.result));
+    }
+    if !result.error.is_null() {
+        drop(CString::from_raw(result.error));
+    }
+}


### PR DESCRIPTION
- Update CompileResult struct handling in Go code
- Fix function signatures to match Rust implementation
- Correct memory management for CompileResult struct