### PR TITLE
APP 9190 Adding aarch64 linux build to release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         use-cross: true
         command: build
-        args: --all --release --target=aarch64-unknown-linux-gnu
+        args: --release --target=aarch64-unknown-linux-gnu
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
+        use-cross: true
         toolchain: stable
         target: ${{ matrix.target }}
         override: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,9 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact_name: libmongosqlwrapper.a
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            artifact_name: libmongosqlwrapper.a
 
     steps:
     - uses: actions/checkout@v4
@@ -74,6 +77,7 @@ jobs:
         ls -la aarch64-apple-darwin-libmongosqlwrapper.a || true
         ls -la x86_64-apple-darwin-libmongosqlwrapper.a || true
         ls -la x86_64-unknown-linux-gnu-libmongosqlwrapper.a || true
+        ls -la aarch64-unknown-linux-gnu-libmongosqlwrapper.a || true
 
     - name: Create Release
       id: create_release
@@ -114,4 +118,14 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: x86_64-unknown-linux-gnu-libmongosqlwrapper.a/libmongosqlwrapper.a
         asset_name: libmongosqlwrapper-x86_64-unknown-linux-gnu.a
+        asset_content_type: application/octet-stream
+
+    - name: Upload Release Assets
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: aarch64-unknown-linux-gnu-libmongosqlwrapper.a/libmongosqlwrapper.a
+        asset_name: libmongosqlwrapper-aarch64-unknown-linux-gnu.a
         asset_content_type: application/octet-stream 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,9 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact_name: libmongosqlwrapper.a
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            artifact_name: libmongosqlwrapper.a
+          # - os: ubuntu-latest
+          #   target: aarch64-unknown-linux-gnu
+          #   artifact_name: libmongosqlwrapper.a
 
     steps:
     - uses: actions/checkout@v4
@@ -40,7 +40,6 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        use-cross: true
         toolchain: stable
         target: ${{ matrix.target }}
         override: true
@@ -53,6 +52,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: cargo build --release --target ${{ matrix.target }}
+
+    - name: Build arm64
+      uses: actions-rs/cargo@v1
+      with:
+        use-cross: true
+        command: build
+        args: --all --release --target=aarch64-unknown-linux-gnu
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,9 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact_name: libmongosqlwrapper.a
-          # - os: ubuntu-latest
-          #   target: aarch64-unknown-linux-gnu
-          #   artifact_name: libmongosqlwrapper.a
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            artifact_name: libmongosqlwrapper.a
 
     steps:
     - uses: actions/checkout@v4
@@ -49,11 +49,13 @@ jobs:
         git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
 
     - name: Build
+      if: matrix.target != 'aarch64-unknown-linux-gnu'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: cargo build --release --target ${{ matrix.target }}
 
     - name: Build arm64
+      if: matrix.target == 'aarch64-unknown-linux-gnu'
       uses: actions-rs/cargo@v1
       with:
         use-cross: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ panic = "abort"
 strip = true
 debug = false
 incremental = false 
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,3 @@ panic = "abort"
 strip = true
 debug = false
 incremental = false 
-
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"


### PR DESCRIPTION
In order to support ongoing Dockerization efforts in the app repo, it would be useful to have a pre-compiled `aarch64-unknown-linux-gnu` version of the library included in the release. This change adds that build architecture to the CI configuration.

Had to do something a bit janky and add a conditional to the CI build that uses a `Build arm64` step only in the case of the linux ARM version of the library. The new step uses `cross` to build the library.